### PR TITLE
Release v0.1.0 - Initial Chat Parser Library

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
-# Cligent
+# Cligent - Chat Parser Library
 
-Chat Parser Library for parsing AI agent conversation logs.
+A Python library for parsing AI agent conversation logs, with specialized support for Claude AI conversations.
 
 ## Installation
 
@@ -8,29 +8,101 @@ Chat Parser Library for parsing AI agent conversation logs.
 pip install cligent
 ```
 
-## Usage
+## Features
+
+- Parse AI conversation logs from JSONL format
+- Support for multi-turn conversations with user, assistant, and system messages
+- Handle tool usage and function calls in conversations
+- Filter and process Claude-specific message formats
+- Export conversations to YAML format
+- Robust error handling for malformed logs
+
+## Quick Start
 
 ```python
-import cligent.chat_parser
+from cligent import ChatParser
 
-# Usage examples will be added as features are implemented
+# Initialize parser with a project directory
+parser = ChatParser("/path/to/project")
+
+# Parse all conversation logs
+chats = parser.parse_logs()
+
+# Access individual messages
+for chat in chats:
+    print(f"Chat ID: {chat.id}")
+    print(f"Messages: {len(chat.messages)}")
+    
+    for message in chat.messages:
+        print(f"  {message.role}: {message.content[:100]}...")
 ```
 
-## Development
+## Advanced Usage
 
-This project uses `uv` for package management:
+### Working with specific stores
 
-```bash
-# Install development dependencies
-uv pip install -e ".[dev]"
+```python
+from cligent import ChatParser, LogStore
 
-# Run tests
-pytest
+# Parse logs from specific Claude Code conversations
+parser = ChatParser("/path/to/project")
 
-# Run linting
-ruff check src/
+# Get available stores
+stores = parser.list_stores()
+
+# Parse logs from a specific store
+store = LogStore("project_name", "/path/to/logs")
+chats = parser.parse_logs(stores=[store])
 ```
+
+### Exporting to YAML
+
+```python
+from cligent import ChatParser
+
+parser = ChatParser("/path/to/project")
+chats = parser.parse_logs()
+
+# Export to YAML format
+yaml_output = parser.export_yaml(chats)
+print(yaml_output)
+```
+
+### Error Handling
+
+```python
+from cligent import ChatParser, ChatParserError, LogCorruptionError
+
+try:
+    parser = ChatParser("/path/to/project")
+    chats = parser.parse_logs()
+except LogCorruptionError as e:
+    print(f"Log file corrupted: {e}")
+except ChatParserError as e:
+    print(f"Parser error: {e}")
+```
+
+## API Reference
+
+### Core Classes
+
+- `ChatParser`: Main parser class for processing conversation logs
+- `Chat`: Represents a complete conversation
+- `Message`: Individual message within a conversation
+- `LogStore`: Represents a storage location for conversation logs
+
+### Exceptions
+
+- `ChatParserError`: Base exception for all parser errors
+- `ParseError`: Error during parsing operations
+- `LogAccessError`: Error accessing log files
+- `LogCorruptionError`: Corrupted or malformed log file
+- `InvalidFormatError`: Invalid message format
 
 ## License
 
-MIT License - see LICENSE file for details.
+This project is licensed under the GNU Affero General Public License v3.0 - see the LICENSE file for details.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "cligent"
 version = "0.1.0"
 description = "Chat Parser Library for parsing AI agent conversation logs"
 readme = "README.md"
-license = { text = "MIT" }
+license = { text = "AGPL-3.0" }
 authors = [
     { name = "Jinglei Ren", email = "jinglei@merico.ai" }
 ]
@@ -15,7 +15,7 @@ keywords = ["chat", "parser", "ai", "agent", "conversation", "logs"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -42,8 +42,11 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets.wheel.force-include]
-"src" = "cligent"
+[tool.hatch.build.targets.wheel]
+packages = ["src/chat_parser"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src/chat_parser" = "cligent"
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src", "pyproject.toml", "README.md"]

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -1,12 +1,3 @@
 """Cligent - Chat Parser Library for parsing AI agent conversation logs."""
 
-from . import chat_parser
-from .chat_parser import ChatParser, Chat, Message
-
 __version__ = "0.1.0"
-__all__ = [
-    "chat_parser",
-    "ChatParser",
-    "Chat", 
-    "Message",
-]


### PR DESCRIPTION
## Initial release of Cligent chat parser functionality

### What's included
- Complete chat parser implementation for AI conversation logs
- Support for JSONL format parsing
- Claude-specific message filtering
- YAML export functionality
- Comprehensive error handling
- Full test coverage

### Package details
- Published to PyPI as `cligent` v0.1.0
- GitHub release: https://github.com/sublang-ai/cligent/releases/tag/v0.1.0
- License: AGPL-3.0

### Installation
```bash
pip install cligent
```

### Quick usage
```python
from cligent import ChatParser

parser = ChatParser("/path/to/project")
chats = parser.parse_logs()
```